### PR TITLE
Fixing dropped email messages due to character conversion error. OCEC…

### DIFF
--- a/tasks/translation_jobs.py
+++ b/tasks/translation_jobs.py
@@ -47,7 +47,7 @@ class ReportTools:
     import lxml.html as HTML
     TEST = "*** TEST MESSAGE *** LIVE MODE WOULD HAVE GONE TO {}"
     SENDER = "PDQ Operator <NCIPDQoperator@mail.nih.gov>"
-    CHARSET = "iso-8859-1"
+    CHARSET = "utf-8"
     TSTYLE = (
         "width: 95%",
         "border: 1px solid #999",
@@ -57,7 +57,7 @@ class ReportTools:
     TSTYLE = "; ".join(TSTYLE)
     TO_STRING_OPTS = {
         "pretty_print": True,
-        "encoding": CHARSET,
+        "encoding": "unicode",
         "doctype": "<!DOCTYPE html>"
     }
 
@@ -108,7 +108,6 @@ class ReportTools:
         html       Tree object created using lxml HTML builder.
         """
 
-        cls.TO_STRING_OPTS = {"encoding": "unicode"}
         return cls.HTML.tostring(html, **cls.TO_STRING_OPTS)
 
     @staticmethod
@@ -364,7 +363,6 @@ class Control(ReportTools):
         recips = CDRTask.get_group_email_addresses(group)
         if recips:
             subject = "[%s] %s" % (cdr.Tier().name, self.title)
-            #cdr.sendMail(self.SENDER, recips, subject, report, html=True)
             cdr.sendMailMime(self.SENDER, recips, subject, report, "html")
             self.logger.info("sent %s", subject)
             self.logger.info("recips: %s", ", ".join(recips))
@@ -437,7 +435,6 @@ class User(ReportTools):
             recips = [self.email]
         if recips:
             subject = "[%s] %s" % (cdr.Tier().name, control.title)
-            #cdr.sendMail(self.SENDER, recips, subject, report, html=True)
             cdr.sendMailMime(self.SENDER, recips, subject, report, "html")
 
             control.logger.info("sent %s", subject)

--- a/tasks/translation_jobs.py
+++ b/tasks/translation_jobs.py
@@ -108,6 +108,7 @@ class ReportTools:
         html       Tree object created using lxml HTML builder.
         """
 
+        cls.TO_STRING_OPTS = {"encoding": "unicode"}
         return cls.HTML.tostring(html, **cls.TO_STRING_OPTS)
 
     @staticmethod
@@ -168,7 +169,7 @@ class Control(ReportTools):
 
     def run(self):
         "Generate and email the report."
-        self.logger.info("top of %s %s run", self.schedule, self.doctype)
+        self.logger.info("*** top of %s %s run", self.schedule, self.doctype)
         if self.schedule == "nightly":
             self.logger.info("loading users")
             for user in self.load_users():
@@ -363,7 +364,8 @@ class Control(ReportTools):
         recips = CDRTask.get_group_email_addresses(group)
         if recips:
             subject = "[%s] %s" % (cdr.Tier().name, self.title)
-            cdr.sendMail(self.SENDER, recips, subject, report, html=True)
+            #cdr.sendMail(self.SENDER, recips, subject, report, html=True)
+            cdr.sendMailMime(self.SENDER, recips, subject, report, "html")
             self.logger.info("sent %s", subject)
             self.logger.info("recips: %s", ", ".join(recips))
         else:
@@ -435,7 +437,9 @@ class User(ReportTools):
             recips = [self.email]
         if recips:
             subject = "[%s] %s" % (cdr.Tier().name, control.title)
-            cdr.sendMail(self.SENDER, recips, subject, report, html=True)
+            #cdr.sendMail(self.SENDER, recips, subject, report, html=True)
+            cdr.sendMailMime(self.SENDER, recips, subject, report, "html")
+
             control.logger.info("sent %s", subject)
             control.logger.info("recips: %s", ", ".join(recips))
         else:


### PR DESCRIPTION
…DR-4517
The character set for the HTML output is set to 'iso-8859-1'.  
Should this be changed to 'utf-8' with my change?